### PR TITLE
Tabs tidy up

### DIFF
--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -1,6 +1,11 @@
 (function() {
 	'use strict';
 
+	const states = {
+		buttonActive: 'tabs__button--active',
+		panelActive: 'tabs__panel--active'
+	};
+
 	window.Code = window.Code || {};
 
 	window.Code.Tabs = function(component) {
@@ -9,11 +14,6 @@
 		const selectors = {
 			buttons: Array.prototype.slice.call(component.querySelectorAll('[data-tabs-button]')),
 			panels: Array.prototype.slice.call(component.querySelectorAll('[data-tabs-panel]'))
-		};
-
-		const states = {
-			buttonActive: 'tabs__button--active',
-			panelActive: 'tabs__panel--active'
 		};
 
 		const keyboardHandlers = {

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -53,16 +53,29 @@
 			activeElements.panel = panel;
 		}
 
+		function setElementsForIndexActive(index) {
+			setActiveElements(
+				component.querySelector(`[${attributes.button}="${index}"]`),
+				component.querySelector(`[${attributes.panel}="${index}"]`)
+			);
+		}
+
 		function getCurrentIndex() {
 			return parseInt(activeElements.button.getAttribute(attributes.button));
 		}
 
 		function setFirstElementActive() {
-			setActiveElements(selectors.buttons[0], selectors.panels[0]);
+			setActiveElements(
+				selectors.buttons[0],
+				selectors.panels[0]
+			);
 		}
 
 		function setLastElementActive() {
-			setActiveElements(selectors.buttons[selectors.buttons.length - 1], selectors.panels[selectors.panels.length - 1]);
+			setActiveElements(
+				selectors.buttons[selectors.buttons.length - 1],
+				selectors.panels[selectors.panels.length - 1]
+			);
 		}
 
 		function goToFirstTab() {
@@ -86,7 +99,7 @@
 				setLastElementActive();
 			} else {
 				currentIndex--;
-				setActiveElements(component.querySelector(`[${attributes.button}="${currentIndex}"]`), component.querySelector(`[${attributes.panel}="${currentIndex}"]`));
+				setElementsForIndexActive(currentIndex);
 			}
 
 			addActiveElement();
@@ -101,7 +114,7 @@
 				setFirstElementActive();
 			} else {
 				currentIndex++;
-				setActiveElements(component.querySelector(`[${attributes.button}="${currentIndex}"]`), component.querySelector(`[${attributes.panel}="${currentIndex}"]`));
+				setElementsForIndexActive(currentIndex);
 			}
 
 			addActiveElement();
@@ -110,7 +123,7 @@
 		function handleClickEvent(event) {
 			const currentIndex = parseInt(event.currentTarget.getAttribute(attributes.button));
 			removeActiveElement();
-			setActiveElements(component.querySelector(`[${attributes.button}="${currentIndex}"]`), component.querySelector(`[${attributes.panel}="${currentIndex}"]`));
+			setElementsForIndexActive(currentIndex);
 			addActiveElement();
 		}
 

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -91,7 +91,7 @@
 		}
 
 		function handleArrowLeftEvent(element) {
-			var currentIndex = getCurrentIndex();
+			let currentIndex = getCurrentIndex();
 
 			removeActiveElement();
 
@@ -106,7 +106,7 @@
 		}
 
 		function handleArrowRightEvent(element) {
-			var currentIndex = getCurrentIndex();
+			let currentIndex = getCurrentIndex();
 
 			removeActiveElement();
 
@@ -145,10 +145,10 @@
 
 	};
 
-	var tabs = Array.prototype.slice.call(document.querySelectorAll('[data-tabs]'));
+	const tabs = Array.prototype.slice.call(document.querySelectorAll('[data-tabs]'));
 
 	tabs.forEach(element => {
-		var newTabs = new window.Code.Tabs(element);
+		const newTabs = new window.Code.Tabs(element);
 	});
 })();
 

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -6,14 +6,19 @@
 		panelActive: 'tabs__panel--active'
 	};
 
+	const attributes = {
+		button: 'data-tabs-button',
+		panel: 'data-tabs-panel',
+	};
+
 	window.Code = window.Code || {};
 
 	window.Code.Tabs = function(component) {
 		'use strict';
 
 		const selectors = {
-			buttons: Array.prototype.slice.call(component.querySelectorAll('[data-tabs-button]')),
-			panels: Array.prototype.slice.call(component.querySelectorAll('[data-tabs-panel]'))
+			buttons: Array.prototype.slice.call(component.querySelectorAll(`[${attributes.button}]`)),
+			panels: Array.prototype.slice.call(component.querySelectorAll(`[${attributes.panel}]`))
 		};
 
 		const keyboardHandlers = {
@@ -49,7 +54,7 @@
 		}
 
 		function getCurrentIndex() {
-			return parseInt(activeElements.button.getAttribute('data-tabs-button'));
+			return parseInt(activeElements.button.getAttribute(attributes.button));
 		}
 
 		function goToFirstTab() {
@@ -73,11 +78,10 @@
 				setActiveElements(selectors.buttons[selectors.buttons.length - 1], selectors.panels[selectors.panels.length - 1]);
 			} else {
 				currentIndex--;
-				setActiveElements(component.querySelector(`[data-tabs-button="${currentIndex}"]`), component.querySelector(`[data-tabs-panel="${currentIndex}"]`));
+				setActiveElements(component.querySelector(`[${attributes.button}="${currentIndex}"]`), component.querySelector(`[${attributes.panel}="${currentIndex}"]`));
 			}
 
 			addActiveElement();
-
 		}
 
 		function handleArrowRightEvent(element) {
@@ -89,16 +93,16 @@
 				setActiveElements(selectors.buttons[0], selectors.panels[0]);
 			} else {
 				currentIndex++;
-				setActiveElements(component.querySelector(`[data-tabs-button="${currentIndex}"]`), component.querySelector(`[data-tabs-panel="${currentIndex}"]`));
+				setActiveElements(component.querySelector(`[${attributes.button}="${currentIndex}"]`), component.querySelector(`[${attributes.panel}="${currentIndex}"]`));
 			}
 
 			addActiveElement();
 		}
 
 		function handleClickEvent(event) {
-			const currentIndex = parseInt(event.currentTarget.getAttribute('data-tabs-button'));
+			const currentIndex = parseInt(event.currentTarget.getAttribute(attributes.button));
 			removeActiveElement();
-			setActiveElements(component.querySelector(`[data-tabs-button="${currentIndex}"]`), component.querySelector(`[data-tabs-panel="${currentIndex}"]`));
+			setActiveElements(component.querySelector(`[${attributes.button}="${currentIndex}"]`), component.querySelector(`[${attributes.panel}="${currentIndex}"]`));
 			addActiveElement();
 		}
 

--- a/components/tabs/tabs.js
+++ b/components/tabs/tabs.js
@@ -57,15 +57,23 @@
 			return parseInt(activeElements.button.getAttribute(attributes.button));
 		}
 
+		function setFirstElementActive() {
+			setActiveElements(selectors.buttons[0], selectors.panels[0]);
+		}
+
+		function setLastElementActive() {
+			setActiveElements(selectors.buttons[selectors.buttons.length - 1], selectors.panels[selectors.panels.length - 1]);
+		}
+
 		function goToFirstTab() {
 			removeActiveElement();
-			setActiveElements(selectors.buttons[0], selectors.panels[0]);
+			setFirstElementActive();
 			addActiveElement();
 		}
 
 		function goToLastTab() {
 			removeActiveElement();
-			setActiveElements(selectors.buttons[selectors.buttons.length - 1], selectors.panels[selectors.panels.length - 1]);
+			setLastElementActive();
 			addActiveElement();
 		}
 
@@ -75,7 +83,7 @@
 			removeActiveElement();
 
 			if(currentIndex === 0) {
-				setActiveElements(selectors.buttons[selectors.buttons.length - 1], selectors.panels[selectors.panels.length - 1]);
+				setLastElementActive();
 			} else {
 				currentIndex--;
 				setActiveElements(component.querySelector(`[${attributes.button}="${currentIndex}"]`), component.querySelector(`[${attributes.panel}="${currentIndex}"]`));
@@ -90,7 +98,7 @@
 			removeActiveElement();
 
 			if(currentIndex === selectors.buttons.length - 1) {
-				setActiveElements(selectors.buttons[0], selectors.panels[0]);
+				setFirstElementActive();
 			} else {
 				currentIndex++;
 				setActiveElements(component.querySelector(`[${attributes.button}="${currentIndex}"]`), component.querySelector(`[${attributes.panel}="${currentIndex}"]`));


### PR DESCRIPTION
Clean up the tabs component with a small amount of refactoring:

- Pulling `states` out of the Tab component so that it's not created each time one is instantiated
- Use a constant for `data-tabs-button` and `data-tabs-panel` rather than repeating them through the file
- Create functions for setting the first and last component to reduce duplication & make intent more clear
- Create a function for setting a specific tab active rather than duplicating the selector